### PR TITLE
fix(README): Improve kdev shell alias definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1091,7 +1091,7 @@ Cleanup is not necessary, because `--rm` parameter deletes deployment after cont
 Run `sikalabs/dev`:
 
 ```
-alias kdev="kubectl run dev-$(date +%s) --rm -ti --image sikalabs/dev -- bash"
+alias kdev='kubectl run "dev-$(date +%s)" --rm -ti --image sikalabs/dev -- bash'
 ```
 
 ### Create Service ClusterIP


### PR DESCRIPTION
Use single quotes around the alias definition to make it a literal string. The subshell command (`date`) is then executed at the time the alias is used and not at the time of alias definition.

So the pod name would change every time (every second to be exact) the alias is called, which is probably intended originally.

Also use double-quotes around subshell command in the alias to protect the output against shell evaluation (whitespace, special symbols, etc.).